### PR TITLE
Add end2end test to make sure Swagger endpoints work

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,45 @@ On Dokku, follow instructions for Dokku databases:
 
 # Testing
 
-* To run unit tests, use: `mvn test`
-  - Unit tests are any methods labelled with the `@Test` annotation that are under the `/src/test/java` hierarchy, and have file names that end in `Test` or `Tests`
-* To run only the integration tests, use: `INTEGRATION=true mvn test-compile failsafe:integration-test`
-  - Integration tests are any methods labelled with `@Test` annotation, that are under the `/src/test/java` hierarchy, and have names starting with `IT` (specifically capital I, capital T).
-  - By convention, we are putting Integration tests (the ones that run with Playwright) under the package `src/test/java/edu/ucsb/cs156/example/web`
-  - Unless you want a particular integration test to *also* be run when you type `mvn test`, do *not*
-  use the suffixes `Test` or `Tests` for the filename.
-  - Note that while `mvn test` is typically sufficient to run tests, we have found that if you haven't compiled the test code yet, running `mvn failsafe:integration-test` may not actually run any of the tests.
+## Unit Tests
+
+* To run all unit tests, use: `mvn test`
+* To run only the tests from `FooTests.java` use: `mvn test -Dtest=FooTests`
+
+Unit tests are any methods labelled with the `@Test` annotation that are under the `/src/test/java` hierarchy, and have file names that end in `Test` or `Tests`
+
+## Integration Tests
+
+To run only the integration tests, use:
+```
+INTEGRATION=true mvn test-compile failsafe:integration-test
+```
+
+To run only the integration tests *and* see the tests run as you run them,
+use:
+
+```
+INTEGRATION=true HEADLESS=false mvn test-compile failsafe:integration-test
+```
+
+To run a particular integration test (e.g. only `HomePageWebIT.java`) use `-Dit.test=ClassName`, for example:
+
+```
+INTEGRATION=true mvn test-compile failsafe:integration-test -Dit.test=HomePageWebIt
+```
+
+or to see it run live:
+```
+INTEGRATION=true HEADLESS=false mvn test-compile failsafe:integration-test -Dit.test=HomePageWebIt
+```
+
+Integration tests are any methods labelled with `@Test` annotation, that are under the `/src/test/java` hierarchy, and have names starting with `IT` (specifically capital I, capital T).
+
+By convention, we are putting Integration tests (the ones that run with Playwright) under the package `src/test/java/edu/ucsb/cs156/example/web`.
+
+Unless you want a particular integration test to *also* be run when you type `mvn test`, do *not* use the suffixes `Test` or `Tests` for the filename.
+
+Note that while `mvn test` is typically sufficient to run tests, we have found that if you haven't compiled the test code yet, running `mvn failsafe:integration-test` may not actually run any of the tests.
+
+To run a single integration test (e.g. only `HomePageWebIT.java`) use `-Dit.test=ClassName`, for example:
+

--- a/src/main/java/edu/ucsb/cs156/example/config/OpenAPIConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/OpenAPIConfig.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
  */
 @OpenAPIDefinition(
   info = @Info(
-  title = "UCSB CMPSC 156 s24, team03",
+  title = "Swagger: UCSB CMPSC 156 team03",
   description = """
     <p><a href='/'>Home Page</a></p>
     <p><a href='/h2-console'>H2 Console (only on localhost)</a></p>

--- a/src/test/java/edu/ucsb/cs156/example/web/SwaggerWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/SwaggerWebIT.java
@@ -15,6 +15,8 @@ import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.AriaRole;
+
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
@@ -36,6 +38,9 @@ public class SwaggerWebIT {
 
         BrowserContext context = browser.newContext();
         page = context.newPage();
+
+        String url = String.format("http://localhost:%d/swagger-ui/index.html", port);
+        page.navigate(url);
     }
 
     @AfterEach
@@ -45,9 +50,6 @@ public class SwaggerWebIT {
 
     @Test
     public void swagger_page_can_be_loaded() throws Exception {
-        String url = String.format("http://localhost:%d/swagger-ui/index.html", port);
-        page.navigate(url);
-
         assertThat(page.getByText("Swagger: UCSB CMPSC 156 team03"))
                 .isVisible();
 
@@ -55,6 +57,33 @@ public class SwaggerWebIT {
                 .isVisible();
 
         assertThat(page.getByText("H2 Console (only on localhost)"))
+                .isVisible();
+    }
+
+    /**
+     * This test checks that the Swagger page has a few of then endpoints for the
+     * UCSBDiningCommons API.
+     * It is probably not necessary to test all controllers or endpoints; we are
+     * mainly checking that
+     * swagger is appropriate configured and operational. Presumably, if one
+     * controller's
+     * endpoints are present, then all controllers' endpoints are present. Think of
+     * it as
+     * a kind of "smoke test" to make sure that Swagger is working, rather than
+     * a comprehensive test of the Swagger page.
+     */
+    @Test
+    public void swagger_page_has_endpoints_for_UCSBDiningCommons() throws Exception {
+
+
+        assertThat(
+                page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("UCSBDiningCommons").setExact(true)))
+                .isVisible();
+
+        assertThat(page.getByText("Get a single commons"))
+                .isVisible();
+
+        assertThat(page.getByText("Update a single commons"))
                 .isVisible();
     }
 

--- a/src/test/java/edu/ucsb/cs156/example/web/SwaggerWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/SwaggerWebIT.java
@@ -1,0 +1,61 @@
+package edu.ucsb.cs156.example.web;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+public class SwaggerWebIT {
+    @Value("${app.playwright.headless:true}")
+    private boolean runHeadless;
+
+    @LocalServerPort
+    private int port;
+
+    private Browser browser;
+    private Page page;
+
+    @BeforeEach
+    public void setup() {
+        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+
+        BrowserContext context = browser.newContext();
+        page = context.newPage();
+    }
+
+    @AfterEach
+    public void teardown() {
+        browser.close();
+    }
+
+    @Test
+    public void swagger_page_can_be_loaded() throws Exception {
+        String url = String.format("http://localhost:%d/swagger-ui/index.html", port);
+        page.navigate(url);
+
+        assertThat(page.getByText("Swagger: UCSB CMPSC 156 team03"))
+                .isVisible();
+
+        assertThat(page.getByText("Home Page"))
+                .isVisible();
+
+        assertThat(page.getByText("H2 Console (only on localhost)"))
+                .isVisible();
+    }
+
+}


### PR DESCRIPTION
In this PR, we add a Playwright based end2end test to ensure that the Swagger endpoints work properly.

We added this because an earlier PR had to be reverted after it resulted in an undetected regression (i.e. it broke Swagger and we didn't notice until after the PR was already merged.)   

Adding this test may help prevent this from happening in the future.

We also improved the README.md coverage concerning how to run the integration tests.