### PR TITLE
pc - DO NOT MERGE disable csrf as test to see if that's the issue

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
     http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
         .exceptionHandling(handling -> handling.authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
         .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
-        .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+        .csrf(csrf -> csrf.disable())
         .logout(logout -> logout.logoutRequestMatcher(new AntPathRequestMatcher("/logout")).logoutSuccessUrl("/"));
     return http.build();
   }


### PR DESCRIPTION
This PR differs from `spring-boot-3` #5  in only one way: the CSRF protection is disabled.

Note that it will pass all of the tests, and work properly when deployed.

However, it has a big security hole that needs to be patched. 

The question is: how?
* Why does what worked in Spring 2 not work here?
* Does it have something to do with `JSESSIONID`?