### PR TITLE
pc - update pom.xml for partial pitest runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.R
 To run pitest on just one package, use:
 
 ```
-mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.*
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.\*
 ```
 
 To run full mutation test coverage, as usual, use:

--- a/README.md
+++ b/README.md
@@ -182,3 +182,24 @@ Unless you want a particular integration test to *also* be run when you type `mv
 Note that while `mvn test` is typically sufficient to run tests, we have found that if you haven't compiled the test code yet, running `mvn failsafe:integration-test` may not actually run any of the tests.
 
 
+## Partial pitest runs
+
+This repo has support for partial pitest runs
+
+For example, to run pitest on just one class, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.RestaurantsController
+```
+
+To run pitest on just one package, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.*
+```
+
+To run full mutation test coverage, as usual, use:
+
+```
+mvn pitest:mutationCoverage
+```

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <mainClass>edu.ucsb.cs156.example.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.example</app.package>
     <app.packagePath>edu/ucsb/cs156/example</app.packagePath>
+    <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
   </properties>
 
   <!-- (22) <dependencyManagement/> -->
@@ -277,7 +278,7 @@
           </historyOutputFile>
           <verbose>true</verbose>
           <targetClasses>
-            <param>edu.ucsb.cs156.*</param>
+            <param>${targetClasses}</param>
           </targetClasses>
           <targetTests>
             <param>edu.ucsb.cs156.*</param>


### PR DESCRIPTION
You can now type, for example:
  mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.RestaurantsController

or:
  mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.*

And it will run pitest on just one class, or just one group of classes in a package.